### PR TITLE
jQuery: Simplify and clean up nomenclature

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,13 +17,13 @@
 		<nav id="navbar">
 			<!-- Not using ul as it introduces a useless and misaligning gap -->
 			<div>
-				<a id="nav-welcome" class="nav-buttons" href="#section-content">Welcome</a>
-				<a id="nav-about" class="nav-buttons" href="#section-content">About</a>
-				<a id="nav-projects" class="nav-buttons" href="#section-content">Projects</a>
-				<a id="nav-contact" class="nav-buttons" href="#section-content">Contact</a>
+				<a id="welcome" class="nav-buttons" href="#content">Welcome</a>
+				<a id="about" class="nav-buttons" href="#content">About</a>
+				<a id="projects" class="nav-buttons" href="#content">Projects</a>
+				<a id="contact" class="nav-buttons" href="#content">Contact</a>
 			</div>
 		</nav>
-		<main id="section-content">
+		<main id="content">
 		</main>
 	</div>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,18 +1,18 @@
 const sectionsArr = [
 	{
-		id: "nav-welcome",
-		location: "./sections/welcome-section.html"
+		id: "welcome",
+		location: "./sections/welcome.html"
 	},
 	{
-		id: "nav-about",
+		id: "about",
 		location: "./sections/about.html"
 	},
 	{
-		id: "nav-projects",
+		id: "projects",
 		location: "./sections/projects.html"
 	},
 	{
-		id: "nav-contact",
+		id: "contact",
 		location: "./sections/contact.html"
 	},
 ];
@@ -23,7 +23,7 @@ const selectNavButton = (id) => {
 };
 
 const updateURLState = (id) => {
-	window.history.pushState({ "nav": id }, "Edrick", "?selected=" + id);
+	window.history.pushState(null, "Edrick", "?section=" + id);
 }
 
 const fetchAndSetSection = (location, target) => {
@@ -47,11 +47,11 @@ const updateSection = (id, target) => {
 
 const main = () => {
 	var currentSection = null;
-	const sectionContent = "#section-content";
+	const sectionContent = "#content";
 
-	currentSection = new URLSearchParams(window.location.search).get('selected');
+	currentSection = new URLSearchParams(window.location.search).get('section');
 	if (currentSection === null)
-		currentSection = "nav-welcome";
+		currentSection = "welcome";
 
 	updateSection(currentSection, sectionContent);
 

--- a/sections/about.html
+++ b/sections/about.html
@@ -1,4 +1,4 @@
-<section id="about" class="translucent-container">
+<section id="section-about" class="translucent-container">
 <div>
 	<img src="./src/profile-photo.JPG">
 	<h2>Edrick Vince Sinsuan</h2>

--- a/sections/contact.html
+++ b/sections/contact.html
@@ -1,4 +1,4 @@
-<section id="contact">
+<section id="section-contact">
 	<h1>Interested? Feel free to contact me or look further.<span id="terminal-anim">_</span></h1>
 	<div>
 	<a id="profile-link" href="https://github.com/ederekun" target="_blank">

--- a/sections/projects.html
+++ b/sections/projects.html
@@ -1,4 +1,4 @@
-<section id="projects">
+<section id="section-projects">
 	<div id="project-tile-container">
 	<a href="https://codepen.io/ederekun/pen/XWZJrVL" target="_blank">
 		<div class="translucent-container project-tile">

--- a/sections/welcome.html
+++ b/sections/welcome.html
@@ -1,3 +1,3 @@
-<section id="welcome-section">
+<section id="section-welcome">
 	<h1>Hello! I am Edrick, a computer systems analyst and software programmer<span id="terminal-anim">_</span></h1>
 </section>

--- a/style.css
+++ b/style.css
@@ -44,22 +44,22 @@ a {
 	padding: 1em 0;
 }
 
-.foreheader-text, #projects h1, #contact h1, #welcome-section h1 {
+.foreheader-text, #section-projects h1, #section-contact h1, #section-welcome h1 {
 	/* Use a nice font-weight */
 	font-weight: 400;
 }
 
-.bnw-select, #contact div a, #about h2, #welcome-section h1, #navbar div a, .project-tile, .foreheader-text, #projects h1, #contact h1 {
+.bnw-select, #section-contact div a, #section-about h2, #section-welcome h1, #navbar div a, .project-tile, .foreheader-text, #section-projects h1, #section-contact h1 {
 	padding: 0.25em 1em;
 }
 
-.bnw-select:hover, #contact div a:hover, #about h2:hover, #welcome-section h1:hover, #navbar div a:hover, .project-tile:hover {
+.bnw-select:hover, #section-contact div a:hover, #section-about h2:hover, #section-welcome h1:hover, #navbar div a:hover, .project-tile:hover {
 	/* Disable shadows, if there's any */
 	text-shadow: none;
 	animation: select 0.5s forwards;
 }
 
-.floating-text, #contact div a, #projects h1, #contact h1, #welcome-section h1 {
+.floating-text, #section-contact div a, #section-projects h1, #section-contact h1, #section-welcome h1 {
 	text-shadow: 2px 2px 4px #000000;
 }
 
@@ -100,18 +100,18 @@ a {
 	color: black;
 }
 
-#section-content section {
+#content section {
 	min-height: 100vh;
 }
 
-#welcome-section {
+#section-welcome {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
 }
-#welcome-section .bnw-select:hover #terminal-anim, #welcome-section #contact div a:hover #terminal-anim, #contact div #welcome-section a:hover #terminal-anim, #welcome-section #about h2:hover #terminal-anim, #about #welcome-section h2:hover #terminal-anim, #welcome-section .project-tile:hover #terminal-anim, #welcome-section #navbar div a:hover #terminal-anim, #navbar div #welcome-section a:hover #terminal-anim, #welcome-section h1:hover #terminal-anim {
+#section-welcome .bnw-select:hover #terminal-anim, #section-welcome #section-contact div a:hover #terminal-anim, #section-contact div #section-welcome a:hover #terminal-anim, #section-welcome #section-about h2:hover #terminal-anim, #section-about #section-welcome h2:hover #terminal-anim, #section-welcome .project-tile:hover #terminal-anim, #section-welcome #navbar div a:hover #terminal-anim, #navbar div #section-welcome a:hover #terminal-anim, #section-welcome h1:hover #terminal-anim {
 	animation-name: terminal-input-inv;
 }
 
@@ -121,14 +121,14 @@ a {
 	animation: terminal-input 1s step-start infinite;
 }
 
-#about {
+#section-about {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;
 	align-items: center;
 	padding: 0 1em;
 }
-#about div {
+#section-about div {
 	display: flex;
 	flex-direction: column;
 	flex-wrap: inherit;
@@ -136,33 +136,33 @@ a {
 	align-items: center;
 	margin: 0 2em;
 }
-#about div h3 {
+#section-about div h3 {
 	font-weight: 200;
 	margin-top: -1em;
 	color: #bfbfbf;
 }
-#about div img {
+#section-about div img {
 	max-width: 300px;
 	min-width: 250px;
 	width: 100%;
 	padding: 2em 0;
 }
-#about aside div {
+#section-about aside div {
 	display: flex;
 	flex-direction: column;
 	flex-wrap: inherit;
 	align-items: baseline;
 	text-align: left;
 }
-#about aside div h3 {
+#section-about aside div h3 {
 	padding: 0.25em 1.25em;
 	color: white;
 }
 
-#projects {
+#section-projects {
 	padding: 0 1em;
 }
-#projects, #contact {
+#section-projects, #section-contact {
 	flex-direction: column;
 }
 #project-tile-container {
@@ -177,13 +177,13 @@ a {
 	margin-top: -0.75em;
 }
 
-#contact div {
+#section-contact div {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
 	justify-content: center;
 }
-#contact div a {
+#section-contact div a {
 	display: flex;
 	flex-direction: inherit;
 	flex-wrap: inherit;
@@ -192,23 +192,23 @@ a {
 	padding: 0 1em;
 	margin: 1em;
 }
-#contact div a i {
+#section-contact div a i {
 	font-size: 1.5em;
 	margin-right: 0.5em;
 }
-#contact div a h2 {
+#section-contact div a h2 {
 	font-size: 1.25em;
 	font-weight: 200;
 }
 
-#projects, #project-tile-container, #contact {
+#section-projects, #project-tile-container, #section-contact {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
 @media only screen and (max-width: 1000px) {
-	#about {
+	#section-about {
 		flex-wrap: wrap;
 		justify-content: center;
 		/* 
@@ -216,10 +216,10 @@ a {
 		 * aligned at the section's center 
 		 */
 	}
-	#about div {
+	#section-about div {
 		align-self: flex-end;
 	}
-	#about aside {
+	#section-about aside {
 		align-self: flex-start;
 	}
 }


### PR DESCRIPTION
Make the token more intuitive by renaming it to 'section.' Given this change, to avoid confusion and redundancy, fix and simplify nomenclature throughout the website with regards to what they represent as much as possible.

Also remove unnecessary object within the pushState call.