### PR TITLE
jQuery: Make the website responsive to history (popstate) navigations

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-	<link type="text/css" rel="stylesheet" href="./style.css">
-	<link type="image/icon" rel="icon" href="./src/e-icon-2.ico">
+	<link type="text/css" rel="stylesheet" href="style.css">
+	<link type="image/icon" rel="icon" href="src/e-icon-2.ico">
 	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
 	<script type="text/javascript" src="script.js"></script>
 </head>

--- a/script.js
+++ b/script.js
@@ -17,14 +17,26 @@ const sectionsArr = [
 	},
 ];
 
+// Refers to the id/class of the content section container to be updated
+const sectionContent = "#content";
+
+const defaultValues = {
+	section: "welcome"
+};
+
 const selectNavButton = (id) => {
 	$(".nav-buttons").removeClass("nav-selected");
 	$("#" + id).addClass("nav-selected");	
 };
 
-const updateURLState = (id) => {
-	window.history.pushState(null, "Edrick", "?section=" + id);
-}
+const updateURLKey = (key, target) => {
+	var currentURLKeys = new URLSearchParams(window.location.search);
+
+	if (currentURLKeys.get(key) != target) {
+		currentURLKeys.set(key, target);
+		window.history.pushState(null, "", "?" + currentURLKeys);
+	}
+};
 
 const fetchAndSetSection = (location, target) => {
 	$(target).animate({ opacity: 0 }, 500, function() {
@@ -40,26 +52,43 @@ const updateSection = (id, target) => {
 		if (element.id == id) {
 			selectNavButton(id);
 			fetchAndSetSection(element.location, target);
-			updateURLState(id);
 		}
 	});
 };
 
-const main = () => {
-	var currentSection = null;
-	const sectionContent = "#content";
+const loadSection = () => {
+	var currentURLKeys = new URLSearchParams(window.location.search);
+	var currentSection = currentURLKeys.get("section");
 
-	currentSection = new URLSearchParams(window.location.search).get('section');
-	if (currentSection === null)
-		currentSection = "welcome";
+	// Add default section key to URL if not provided
+	if (currentSection === null) {
+		currentSection = defaultValues.section;
+		currentURLKeys.set("section", currentSection);
+		window.history.replaceState(null, "", "?" + currentURLKeys);
+	}
 
 	updateSection(currentSection, sectionContent);
-
-	$(".nav-buttons").click(function() {
-		updateSection($(this).attr("id"), sectionContent);
-	});
 };
 
+// To prevent refreshing the section unnecessarily when navigating history
+var storedCurrentSection;
+
+// Listens for history state pushes and navigations
+window.addEventListener("popstate", (event) => {
+	var currentURLKeys = new URLSearchParams(window.location.search);
+	var currentSection = currentURLKeys.get("section");
+
+	if (storedCurrentSection != currentSection) {
+		storedCurrentSection = currentSection;
+		updateSection(currentURLKeys.get("section"), sectionContent);
+	}
+});
+
 $(document).ready(function() {
-	main();
+	loadSection();
+
+	$(".nav-buttons").click(function() {
+		// Just update URL section key, it invokes popstate event
+		updateURLKey("section", $(this).attr("id"));
+	});
 });

--- a/script.js
+++ b/script.js
@@ -1,19 +1,19 @@
 const sectionsArr = [
 	{
 		id: "welcome",
-		location: "./sections/welcome.html"
+		location: "sections/welcome.html"
 	},
 	{
 		id: "about",
-		location: "./sections/about.html"
+		location: "sections/about.html"
 	},
 	{
 		id: "projects",
-		location: "./sections/projects.html"
+		location: "sections/projects.html"
 	},
 	{
 		id: "contact",
-		location: "./sections/contact.html"
+		location: "sections/contact.html"
 	},
 ];
 

--- a/script.js
+++ b/script.js
@@ -42,8 +42,8 @@ const fetchAndSetSection = (location, target) => {
 	$(target).animate({ opacity: 0 }, 500, function() {
 		$.get(location, function(data) {
 			$(target).html(data);
+			$(target).animate({ opacity: 1 }, 500);
 		});
-		$(target).animate({ opacity: 1 }, 500);
 	});
 };
 


### PR DESCRIPTION
Add an event listener to popstate for the website to update when the user
clicks the back/forward button. This allows us to simply invoke a pushstate
with the navigation buttons and also separate the URL key updates from the
section update function - making the updateSection's purpose solely for
updating the website content. Alongside this addition, also refactor the
whole script for better readability and avoid redundancy at certain
code paths.
